### PR TITLE
fix: error states, compile options, DI dispatcher, runCatching consistency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -66,7 +66,7 @@ android {
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xreturn-value-checker=full")
-        jvmTarget = JvmTarget.JVM_1_8
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 
@@ -130,7 +130,6 @@ dependencies {
     implementation(libs.moshi.kotlin)
     implementation(libs.androidx.graphics.shapes)
     implementation(libs.androidx.material.icons.extended.android)
-    implementation(libs.material3)
 
     // Hilt and Dagger
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
@@ -13,7 +13,6 @@ import com.codingpit.pvpcplanner.domain.usecase.GetDevices
 import com.codingpit.pvpcplanner.domain.usecase.GetPricesFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -35,7 +34,7 @@ class DevicesViewModel
         private val calculateBestTimeSlot: CalculateBestTimeSlot,
         private val calculateDeviceCost: CalculateDeviceCost,
         private val errorHandler: ErrorHandler,
-        private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        private val dispatcher: CoroutineDispatcher,
     ) : ViewModel() {
         private val searchQuery = MutableStateFlow("")
 

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -42,6 +43,9 @@ fun HomeScreen(viewModel: HomeViewModel) {
         }
 
         is HomeState.Error -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(text = state.error)
+            }
         }
     }
 }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.codingpit.pvpcplanner.R
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.models.TimeFormat
 import com.codingpit.pvpcplanner.ui.components.PricesComponent
@@ -44,7 +46,7 @@ fun HomeScreen(viewModel: HomeViewModel) {
 
         is HomeState.Error -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(text = state.error)
+                Text(text = stringResource(R.string.error_generic))
             }
         }
     }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeViewModel.kt
@@ -48,7 +48,7 @@ class HomeViewModel
                     )
                 }.handleErrors(errorHandler, "home_data", HomeState.Factory)
                 .flowOn(coroutineDispatcher)
-                .stateIn(viewModelScope, SharingStarted.Eagerly, HomeState.Loading)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HomeState.Loading)
 
         fun onPreviousClicked() {
             viewModelScope.launch {

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.codingpit.pvpcplanner.R
 import com.codingpit.pvpcplanner.ui.components.AnimatedBottomSheet
 
 @Composable
@@ -43,7 +44,7 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
                     viewModel.updateSetting(setting, option)
                 }
 
-            is SettingsState.Error -> SettingsScreen_Error(state.error)
+            is SettingsState.Error -> SettingsScreen_Error()
         }
     }
 }
@@ -145,9 +146,9 @@ private fun SettingsOptionItem(
 }
 
 @Composable
-private fun SettingsScreen_Error(error: String) {
+private fun SettingsScreen_Error() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = error)
+        Text(text = stringResource(R.string.error_generic))
     }
 }
 

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.ui.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -41,7 +43,7 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
                     viewModel.updateSetting(setting, option)
                 }
 
-            is SettingsState.Error -> SettingsScreen_Error()
+            is SettingsState.Error -> SettingsScreen_Error(state.error)
         }
     }
 }
@@ -143,11 +145,17 @@ private fun SettingsOptionItem(
 }
 
 @Composable
-private fun SettingsScreen_Error() {
+private fun SettingsScreen_Error(error: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = error)
+    }
 }
 
 @Composable
 private fun SettingsScreen_Loading() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import com.codingpit.pvpcplanner.domain.models.TimeFormat
 import com.codingpit.pvpcplanner.domain.usecase.GetSettings
 import com.codingpit.pvpcplanner.domain.usecase.UpdateSetting
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOn
@@ -63,6 +64,7 @@ class SettingsViewModel
                         }
                     }
                 }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     errorHandler.handleError(e, "update_setting")
                 }
             }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/settings/SettingsViewModel.kt
@@ -41,7 +41,7 @@ class SettingsViewModel
             option: SettingOption,
         ) {
             viewModelScope.launch(coroutineDispatcher) {
-                try {
+                runCatching {
                     when (render.setting) {
                         is SettingValue.DarkMode -> {
                             updateSettingUseCase(
@@ -62,7 +62,7 @@ class SettingsViewModel
                             )
                         }
                     }
-                } catch (e: Exception) {
+                }.onFailure { e ->
                     errorHandler.handleError(e, "update_setting")
                 }
             }


### PR DESCRIPTION
## Summary
- Show error message text in `HomeScreen` and `SettingsScreen` error states (previously empty)
- Show `CircularProgressIndicator` in `SettingsScreen` loading state
- Fix `compileOptions` and `jvmTarget` from `1_8` to `17` (matches Java toolchain)
- Remove duplicate `implementation(libs.material3)` dependency
- Remove hardcoded `Dispatchers.IO` default in `DevicesViewModel` — dispatcher is now always injected
- Replace `try/catch` with `runCatching` in `SettingsViewModel` per project guidelines
- Switch `HomeViewModel` from `SharingStarted.Eagerly` to `WhileSubscribed(5000)` for consistency

## Test plan
- [ ] Trigger a network error on Home screen and verify error message appears
- [ ] Verify Settings screen shows spinner while loading
- [ ] Build release variant to confirm compile options change works
- [ ] Run `./gradlew testDebugUnitTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve UI feedback for settings and home error/loading states, align JVM configuration with Java 17, and refine coroutine usage and dependency injection consistency.

Bug Fixes:
- Display error messages in Home and Settings screens instead of empty error states.
- Show a centered loading spinner in the Settings screen while data is loading.

Enhancements:
- Update Android compileOptions and Kotlin jvmTarget to Java 17 to match the toolchain.
- Remove a duplicate Material3 dependency from the app module.
- Inject the coroutine dispatcher into DevicesViewModel instead of defaulting to Dispatchers.IO for better DI consistency.
- Use runCatching with onFailure in SettingsViewModel to standardize error handling.
- Change HomeViewModel state sharing from Eagerly to WhileSubscribed(5000) for consistent flow lifecycle behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Error messages now display on Home and Settings screens.
  * Loading indicator now visible on Settings screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->