### PR TITLE
refactor: replace string navigation constants with sealed class Screen

### DIFF
--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/main/MainScreen.kt
@@ -19,7 +19,6 @@ import com.codingpit.pvpcplanner.ui.home.HomeViewModel
 import com.codingpit.pvpcplanner.ui.main.components.MainBottomBarNav
 import com.codingpit.pvpcplanner.ui.main.components.MainContent
 import com.codingpit.pvpcplanner.ui.settings.SettingsViewModel
-import com.codingpit.pvpcplanner.utils.Constants
 
 @Composable
 fun MainScreen(
@@ -28,29 +27,28 @@ fun MainScreen(
     deviceAddViewModel: DeviceAddViewModel,
     settingsViewModel: SettingsViewModel,
 ) {
-    var selectedScreen by remember { mutableStateOf(Constants.HOME_SCREEN) }
+    var selectedScreen by remember { mutableStateOf<Screen>(Screen.Home) }
     var deviceToEdit by remember { mutableStateOf<Device?>(null) }
 
     val title =
         when (selectedScreen) {
-            Constants.HOME_SCREEN -> stringResource(R.string.nav_prices)
-            Constants.DEVICES_SCREEN -> stringResource(R.string.nav_devices)
-            Constants.DEVICE_ADD_SCREEN -> null
-            Constants.SETTINGS_SCREEN -> stringResource(R.string.nav_settings)
-            else -> selectedScreen
+            is Screen.Home -> stringResource(R.string.nav_prices)
+            is Screen.Devices -> stringResource(R.string.nav_devices)
+            is Screen.DeviceAdd -> null
+            is Screen.Settings -> stringResource(R.string.nav_settings)
         }
 
-    val showBottomBar = selectedScreen != Constants.DEVICE_ADD_SCREEN
+    val showBottomBar = selectedScreen !is Screen.DeviceAdd
 
     ScaffoldScreen(
         title = title,
         fab = {
             when (selectedScreen) {
-                Constants.HOME_SCREEN -> {}
-                Constants.DEVICES_SCREEN -> {
+                is Screen.Home -> {}
+                is Screen.Devices -> {
                     FloatingActionButton(onClick = {
                         deviceToEdit = null
-                        selectedScreen = Constants.DEVICE_ADD_SCREEN
+                        selectedScreen = Screen.DeviceAdd
                     }) {
                         Icon(Icons.Filled.Add, stringResource(R.string.action_add))
                     }
@@ -77,15 +75,15 @@ fun MainScreen(
             deviceToEdit = deviceToEdit,
             onNavigateToDeviceAdd = {
                 deviceToEdit = null
-                selectedScreen = Constants.DEVICE_ADD_SCREEN
+                selectedScreen = Screen.DeviceAdd
             },
             onNavigateToDeviceEdit = { device ->
                 deviceToEdit = device
-                selectedScreen = Constants.DEVICE_ADD_SCREEN
+                selectedScreen = Screen.DeviceAdd
             },
             onNavigateBack = {
                 deviceToEdit = null
-                selectedScreen = Constants.DEVICES_SCREEN
+                selectedScreen = Screen.Devices
             },
         )
     }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/main/Screen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/main/Screen.kt
@@ -1,0 +1,8 @@
+package com.codingpit.pvpcplanner.ui.main
+
+sealed class Screen {
+    object Home : Screen()
+    object Devices : Screen()
+    object DeviceAdd : Screen()
+    object Settings : Screen()
+}

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainBottomBarNav.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainBottomBarNav.kt
@@ -14,13 +14,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codingpit.pvpcplanner.R
-import com.codingpit.pvpcplanner.utils.Constants
+import com.codingpit.pvpcplanner.ui.main.Screen
 import com.codingpit.pvpcplanner.utils.Constants.ROUTES_NAVIGATION_BOTTOM_BAR
 
 @Composable
 fun MainBottomBarNav(
-    selectedScreen: String,
-    onScreenSelected: (String) -> Unit,
+    selectedScreen: Screen,
+    onScreenSelected: (Screen) -> Unit,
     iconSize: Int = 22,
     fontSize: Int = 14,
 ) {
@@ -30,10 +30,10 @@ fun MainBottomBarNav(
         ROUTES_NAVIGATION_BOTTOM_BAR.forEach { screen ->
             val label =
                 when (screen.key) {
-                    Constants.HOME_SCREEN -> stringResource(R.string.nav_prices)
-                    Constants.DEVICES_SCREEN -> stringResource(R.string.nav_devices)
-                    Constants.SETTINGS_SCREEN -> stringResource(R.string.nav_settings)
-                    else -> screen.key
+                    is Screen.Home -> stringResource(R.string.nav_prices)
+                    is Screen.Devices -> stringResource(R.string.nav_devices)
+                    is Screen.Settings -> stringResource(R.string.nav_settings)
+                    else -> ""
                 }
 
             NavigationBarItem(
@@ -61,7 +61,7 @@ fun MainBottomBarNav(
 @Composable
 private fun BottomBar_Preview() {
     MainBottomBarNav(
-        selectedScreen = "HomeScreen",
+        selectedScreen = Screen.Home,
         onScreenSelected = {},
     )
 }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainBottomBarNav.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainBottomBarNav.kt
@@ -32,8 +32,8 @@ fun MainBottomBarNav(
                 when (screen.key) {
                     is Screen.Home -> stringResource(R.string.nav_prices)
                     is Screen.Devices -> stringResource(R.string.nav_devices)
+                    is Screen.DeviceAdd -> stringResource(R.string.nav_devices)
                     is Screen.Settings -> stringResource(R.string.nav_settings)
-                    else -> ""
                 }
 
             NavigationBarItem(

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainContent.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/main/components/MainContent.kt
@@ -8,12 +8,9 @@ import com.codingpit.pvpcplanner.ui.devices.DevicesScreen
 import com.codingpit.pvpcplanner.ui.devices.DevicesViewModel
 import com.codingpit.pvpcplanner.ui.home.HomeScreen
 import com.codingpit.pvpcplanner.ui.home.HomeViewModel
+import com.codingpit.pvpcplanner.ui.main.Screen
 import com.codingpit.pvpcplanner.ui.settings.SettingsScreen
 import com.codingpit.pvpcplanner.ui.settings.SettingsViewModel
-import com.codingpit.pvpcplanner.utils.Constants.DEVICES_SCREEN
-import com.codingpit.pvpcplanner.utils.Constants.DEVICE_ADD_SCREEN
-import com.codingpit.pvpcplanner.utils.Constants.HOME_SCREEN
-import com.codingpit.pvpcplanner.utils.Constants.SETTINGS_SCREEN
 
 @Composable
 fun MainContent(
@@ -21,32 +18,32 @@ fun MainContent(
     devicesViewModel: DevicesViewModel,
     deviceAddViewModel: DeviceAddViewModel,
     settingsViewModel: SettingsViewModel,
-    selectedScreen: String,
+    selectedScreen: Screen,
     deviceToEdit: Device? = null,
     onNavigateToDeviceAdd: () -> Unit = {},
     onNavigateToDeviceEdit: (Device) -> Unit = {},
     onNavigateBack: () -> Unit = {},
 ) {
     when (selectedScreen) {
-        HOME_SCREEN ->
+        is Screen.Home ->
             HomeScreen(
                 viewModel = homeViewModel,
             )
 
-        DEVICES_SCREEN ->
+        is Screen.Devices ->
             DevicesScreen(
                 viewModel = devicesViewModel,
                 onDeviceClick = onNavigateToDeviceEdit,
             )
 
-        DEVICE_ADD_SCREEN ->
+        is Screen.DeviceAdd ->
             DeviceAddScreen(
                 viewModel = deviceAddViewModel,
                 device = deviceToEdit,
                 onBackClick = onNavigateBack,
             )
 
-        SETTINGS_SCREEN ->
+        is Screen.Settings ->
             SettingsScreen(viewModel = settingsViewModel)
     }
 }

--- a/app/src/main/java/com/codingpit/pvpcplanner/utils/Constants.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/utils/Constants.kt
@@ -31,18 +31,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import com.codingpit.pvpcplanner.R
 import com.codingpit.pvpcplanner.domain.models.DeviceCategory
+import com.codingpit.pvpcplanner.ui.main.Screen
 
 object Constants {
-    const val HOME_SCREEN = "Prices"
-    const val DEVICES_SCREEN = "Devices"
-    const val DEVICE_ADD_SCREEN = "DeviceAdd"
-    const val SETTINGS_SCREEN = "Settings"
-
     val ROUTES_NAVIGATION_BOTTOM_BAR =
         mapOf(
-            HOME_SCREEN to Icons.Default.Paid,
-            DEVICES_SCREEN to Icons.Default.PowerSettingsNew,
-            SETTINGS_SCREEN to Icons.Default.Settings,
+            Screen.Home to Icons.Default.Paid,
+            Screen.Devices to Icons.Default.PowerSettingsNew,
+            Screen.Settings to Icons.Default.Settings,
         )
 }
 


### PR DESCRIPTION
## Summary

- Introduces a `Screen` sealed class (`Screen.Home`, `Screen.Devices`, `Screen.DeviceAdd`, `Screen.Settings`) in `ui/main/Screen.kt` to replace the four raw string constants that were spread across `Constants.kt`
- Updates `Constants.ROUTES_NAVIGATION_BOTTOM_BAR` to use `Screen` objects as map keys instead of strings
- Migrates `MainScreen`, `MainContent`, and `MainBottomBarNav` to use `Screen` as the selected-screen type, replacing all `String` parameters and `when` branches

## Why this matters

The previous approach stored screen destinations as plain strings (`"Prices"`, `"Devices"`, etc.). Any typo, forgotten constant, or addition of a new screen without updating every `when` block would compile silently and cause a runtime no-op (the screen simply wouldn't render). With the sealed class:

- The compiler enforces exhaustive `when` expressions — a missing branch is a compile error, not a silent bug
- Invalid screen names are impossible to construct
- Navigation call sites are refactored with the full IDE support (rename, find usages, etc.)

## Test plan

- [x] `./gradlew compileDebugKotlin` passes with no new errors
- [ ] Launch app on emulator/device and verify Home, Devices, Add Device, and Settings screens all navigate correctly
- [ ] Verify FAB on Devices screen still navigates to DeviceAdd
- [ ] Verify back navigation from DeviceAdd returns to Devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace string-based navigation routes with a sealed Screen type across main UI navigation.

Enhancements:
- Introduce a sealed Screen class to model main navigation destinations.
- Update navigation state, bottom bar, and main content composables to use Screen instead of raw strings.
- Refactor bottom bar route mapping to use Screen keys rather than string constants.
- Remove obsolete string route constants from Constants and centralize screen definitions in ui/main/Screen.kt.