### PR TITLE
feat: show cached data indicator on Home screen

### DIFF
--- a/app/src/main/java/com/codingpit/pvpcplanner/data/PriceRepository.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/data/PriceRepository.kt
@@ -1,7 +1,7 @@
 package com.codingpit.pvpcplanner.data
 
-import com.codingpit.pvpcplanner.domain.models.PVPCModel
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 
 interface PriceRepository {
-    suspend fun getPrices(date: String): Result<List<PVPCModel>>
+    suspend fun getPrices(date: String): Result<PriceFetchResult>
 }

--- a/app/src/main/java/com/codingpit/pvpcplanner/data/PriceRepositoryImpl.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/data/PriceRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.codingpit.pvpcplanner.data
 
 import com.codingpit.pvpcplanner.data.local.sources.PriceLocalDataSource
 import com.codingpit.pvpcplanner.data.remote.RemoteDataSource
-import com.codingpit.pvpcplanner.domain.models.PVPCModel
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import javax.inject.Inject
 
 class PriceRepositoryImpl
@@ -11,14 +11,15 @@ class PriceRepositoryImpl
         private val remoteDataSource: RemoteDataSource,
         private val localDataSource: PriceLocalDataSource,
     ) : PriceRepository {
-        override suspend fun getPrices(date: String): Result<List<PVPCModel>> =
+        override suspend fun getPrices(date: String): Result<PriceFetchResult> =
             runCatching {
                 val localPrices = localDataSource.getPrices(date)
-
-                localPrices.ifEmpty {
+                if (localPrices.isNotEmpty()) {
+                    PriceFetchResult(prices = localPrices, isFromCache = true)
+                } else {
                     val remotePrices = remoteDataSource.getPrices(date)
                     localDataSource.savePrices(remotePrices)
-                    remotePrices
+                    PriceFetchResult(prices = remotePrices, isFromCache = false)
                 }
             }
     }

--- a/app/src/main/java/com/codingpit/pvpcplanner/domain/models/PriceFetchResult.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/domain/models/PriceFetchResult.kt
@@ -1,0 +1,6 @@
+package com.codingpit.pvpcplanner.domain.models
+
+data class PriceFetchResult(
+    val prices: List<PVPCModel>,
+    val isFromCache: Boolean,
+)

--- a/app/src/main/java/com/codingpit/pvpcplanner/domain/usecase/GetPrices.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/domain/usecase/GetPrices.kt
@@ -1,7 +1,7 @@
 package com.codingpit.pvpcplanner.domain.usecase
 
 import com.codingpit.pvpcplanner.data.PriceRepository
-import com.codingpit.pvpcplanner.domain.models.PVPCModel
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.utils.DateFormatter
 import java.time.LocalDate
 import javax.inject.Inject
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class GetPrices @Inject constructor(
     private val repository: PriceRepository,
 ) {
-    suspend operator fun invoke(date: String = ""): Result<List<PVPCModel>> =
+    suspend operator fun invoke(date: String = ""): Result<PriceFetchResult> =
         repository.getPrices(date.takeIf { it.isNotEmpty() } ?: getDate())
 
     private fun getDate(): String {

--- a/app/src/main/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesFlow.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesFlow.kt
@@ -1,7 +1,7 @@
 package com.codingpit.pvpcplanner.domain.usecase
 
 import com.codingpit.pvpcplanner.data.PriceRepository
-import com.codingpit.pvpcplanner.domain.models.PVPCModel
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.utils.DateChecker
 import com.codingpit.pvpcplanner.utils.toParsedDate
 import kotlinx.coroutines.flow.Flow
@@ -12,7 +12,7 @@ class GetPricesFlow @Inject constructor(
     private val repository: PriceRepository,
     private val dateChecker: DateChecker,
 ) {
-    operator fun invoke(date: String = ""): Flow<Result<List<PVPCModel>>> =
+    operator fun invoke(date: String = ""): Flow<Result<PriceFetchResult>> =
         flow {
             emit(
                 repository.getPrices(

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
@@ -45,11 +45,11 @@ class DevicesViewModel
                 getPricesFlow(),
                 searchQuery,
             ) { devices, prices, query ->
-                prices.map { prices ->
+                prices.map { fetchResult ->
                     val devicesSlot =
                         devices.map { device ->
-                            val bestSlot = calculateBestTimeSlot(device, prices)
-                            val cost = calculateDeviceCost(device, bestSlot, prices)
+                            val bestSlot = calculateBestTimeSlot(device, fetchResult.prices)
+                            val cost = calculateDeviceCost(device, bestSlot, fetchResult.prices)
                             DeviceRender(device, bestSlot, cost)
                         }
                     DevicesState.Success(devicesSlot = devicesSlot, searchQuery = query)

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeScreen.kt
@@ -1,17 +1,29 @@
 package com.codingpit.pvpcplanner.ui.home
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.codingpit.pvpcplanner.R
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.models.TimeFormat
 import com.codingpit.pvpcplanner.ui.components.PricesComponent
@@ -28,17 +40,46 @@ fun HomeScreen(viewModel: HomeViewModel) {
         }
 
         is HomeState.Success -> {
-            HomeComponents(
-                pvpcEntries = state.pvpcEntries,
-                selectedDate = state.selectedDate,
-                nextDayEnabled = state.nextDateEnabled,
-                currentPrice = state.currentPrice,
-                currentHour = state.currentHour,
-                currentDate = state.currentDate,
-                timeFormat = state.timeFormat,
-                onPreviousClicked = { viewModel.onPreviousClicked() },
-                onNextClicked = { viewModel.onNextClicked() },
-            )
+            Column(modifier = Modifier.fillMaxSize()) {
+                if (state.isFromCache) {
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        shape = RoundedCornerShape(8.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.WifiOff,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                            Text(
+                                text = stringResource(R.string.cached_data_banner),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                }
+                HomeComponents(
+                    pvpcEntries = state.pvpcEntries,
+                    selectedDate = state.selectedDate,
+                    nextDayEnabled = state.nextDateEnabled,
+                    currentPrice = state.currentPrice,
+                    currentHour = state.currentHour,
+                    currentDate = state.currentDate,
+                    timeFormat = state.timeFormat,
+                    onPreviousClicked = { viewModel.onPreviousClicked() },
+                    onNextClicked = { viewModel.onNextClicked() },
+                )
+            }
         }
 
         is HomeState.Error -> {

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeState.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeState.kt
@@ -17,6 +17,7 @@ sealed class HomeState {
         val currentPrice: Double = 0.0,
         val currentHour: Int = 0,
         val timeFormat: TimeFormat = TimeFormat.TWENTY_FOUR_HOURS,
+        val isFromCache: Boolean = false,
     ) : HomeState()
 
     data class Error(

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/home/HomeViewModel.kt
@@ -37,14 +37,16 @@ class HomeViewModel
                     prices to settings
                 }.map { (it, settings) ->
                     val currentHour = useCaseProvider.getLocalHour()
+                    val fetchResult = it.getOrThrow()
                     HomeState.Success(
                         selectedDate = selectedDate.value.toParsedDate(),
-                        pvpcEntries = it.getOrThrow(),
+                        pvpcEntries = fetchResult.prices,
                         nextDateEnabled = useCaseProvider.isValidDate(selectedDate.value),
-                        currentPrice = it.getOrThrow().first { it.startHour == currentHour }.pcb,
+                        currentPrice = fetchResult.prices.first { price -> price.startHour == currentHour }.pcb,
                         currentHour = currentHour,
                         currentDate = useCaseProvider.getLocalDate().toParsedDate(),
                         timeFormat = settings.timeFormat,
+                        isFromCache = fetchResult.isFromCache,
                     )
                 }.handleErrors(errorHandler, "home_data", HomeState.Factory)
                 .flowOn(coroutineDispatcher)

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -108,4 +108,5 @@
     <string name="select_icon">Seleccionar icono</string>
     <string name="select_category">Seleccionar categoría</string>
     <string name="action_close">Cerrar</string>
+    <string name="cached_data_banner">Mostrando datos en caché. Conecta para actualizar los precios.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,5 @@
     <string name="select_icon">Select icon</string>
     <string name="select_category">Select category</string>
     <string name="action_close">Close</string>
+    <string name="cached_data_banner">Showing cached data. Connect to update prices.</string>
 </resources>

--- a/app/src/test/java/com/codingpit/pvpcplanner/data/PriceRepositoryImplTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/data/PriceRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.data
 
 import com.codingpit.pvpcplanner.data.local.sources.PriceLocalDataSource
 import com.codingpit.pvpcplanner.data.remote.RemoteDataSource
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -39,7 +40,9 @@ class PriceRepositoryImplTest {
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(localPrices, result.getOrNull())
+            val fetchResult = result.getOrNull()
+            assertEquals(localPrices, fetchResult?.prices)
+            assertEquals(true, fetchResult?.isFromCache)
             coVerify { mockLocalDataSource.getPrices(date) }
             coVerify(exactly = 0) { mockRemoteDataSource.getPrices(any()) }
         }
@@ -63,7 +66,9 @@ class PriceRepositoryImplTest {
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(remotePrices, result.getOrNull())
+            val fetchResult = result.getOrNull()
+            assertEquals(remotePrices, fetchResult?.prices)
+            assertEquals(false, fetchResult?.isFromCache)
             coVerify { mockLocalDataSource.getPrices(date) }
             coVerify { mockRemoteDataSource.getPrices(date) }
             coVerify { mockLocalDataSource.savePrices(remotePrices) }

--- a/app/src/test/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesFlowTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesFlowTest.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.domain.usecase
 
 import app.cash.turbine.test
 import com.codingpit.pvpcplanner.data.PriceRepository
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.utils.DateChecker
 import io.mockk.coEvery
@@ -36,7 +37,8 @@ class GetPricesFlowTest {
                     PVPCModel("2023-10-15", 0, 1, 0.15, 0.18),
                     PVPCModel("2023-10-15", 1, 2, 0.14, 0.17),
                 )
-            coEvery { mockRepository.getPrices(date) } returns Result.success(expectedPrices)
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
+            coEvery { mockRepository.getPrices(date) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase(date)
@@ -45,7 +47,7 @@ class GetPricesFlowTest {
             result.test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(expectedPrices, item.getOrNull())
+                assertEquals(expectedResult, item.getOrNull())
                 awaitComplete()
             }
             coVerify { mockRepository.getPrices(date) }
@@ -62,10 +64,11 @@ class GetPricesFlowTest {
                 listOf(
                     PVPCModel("2023-10-15", 0, 1, 0.15, 0.18),
                 )
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
             every { mockDateChecker.getDefaultDate() } returns defaultDate
             coEvery { mockRepository.getPrices(expectedDateString) } returns
                 Result.success(
-                    expectedPrices,
+                    expectedResult,
                 )
 
             // Act
@@ -75,7 +78,7 @@ class GetPricesFlowTest {
             result.test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(expectedPrices, item.getOrNull())
+                assertEquals(expectedResult, item.getOrNull())
                 awaitComplete()
             }
             verify { mockDateChecker.getDefaultDate() }
@@ -92,10 +95,11 @@ class GetPricesFlowTest {
                 listOf(
                     PVPCModel("2023-10-16", 0, 1, 0.16, 0.19),
                 )
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
             every { mockDateChecker.getDefaultDate() } returns defaultDate
             coEvery { mockRepository.getPrices(expectedDateString) } returns
                 Result.success(
-                    expectedPrices,
+                    expectedResult,
                 )
 
             // Act
@@ -105,7 +109,7 @@ class GetPricesFlowTest {
             result.test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(expectedPrices, item.getOrNull())
+                assertEquals(expectedResult, item.getOrNull())
                 awaitComplete()
             }
             verify { mockDateChecker.getDefaultDate() }
@@ -166,7 +170,8 @@ class GetPricesFlowTest {
                 listOf(
                     PVPCModel("2023-12-25", 0, 1, 0.12, 0.15),
                 )
-            coEvery { mockRepository.getPrices(futureDate) } returns Result.success(expectedPrices)
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
+            coEvery { mockRepository.getPrices(futureDate) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase(futureDate)
@@ -175,7 +180,7 @@ class GetPricesFlowTest {
             result.test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(expectedPrices, item.getOrNull())
+                assertEquals(expectedResult, item.getOrNull())
                 awaitComplete()
             }
             coVerify { mockRepository.getPrices(futureDate) }
@@ -187,7 +192,8 @@ class GetPricesFlowTest {
             // Arrange
             val date = "2023-10-15"
             val emptyPrices = emptyList<PVPCModel>()
-            coEvery { mockRepository.getPrices(date) } returns Result.success(emptyPrices)
+            val expectedResult = PriceFetchResult(emptyPrices, isFromCache = false)
+            coEvery { mockRepository.getPrices(date) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase(date)
@@ -196,7 +202,7 @@ class GetPricesFlowTest {
             result.test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(emptyPrices, item.getOrNull())
+                assertEquals(expectedResult, item.getOrNull())
                 awaitComplete()
             }
             coVerify { mockRepository.getPrices(date) }

--- a/app/src/test/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/domain/usecase/GetPricesTest.kt
@@ -1,6 +1,7 @@
 package com.codingpit.pvpcplanner.domain.usecase
 
 import com.codingpit.pvpcplanner.data.PriceRepository
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -30,14 +31,15 @@ class GetPricesTest {
                     PVPCModel("2023-10-15", 0, 1, 0.15, 0.18),
                     PVPCModel("2023-10-15", 1, 2, 0.14, 0.17),
                 )
-            coEvery { mockRepository.getPrices(date) } returns Result.success(expectedPrices)
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
+            coEvery { mockRepository.getPrices(date) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase(date)
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(expectedPrices, result.getOrNull())
+            assertEquals(expectedResult, result.getOrNull())
             coVerify { mockRepository.getPrices(date) }
         }
 
@@ -49,15 +51,16 @@ class GetPricesTest {
                 listOf(
                     PVPCModel("2023-10-15", 0, 1, 0.15, 0.18),
                 )
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
             // The use case will generate today's date when empty string is passed
-            coEvery { mockRepository.getPrices(any()) } returns Result.success(expectedPrices)
+            coEvery { mockRepository.getPrices(any()) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase("")
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(expectedPrices, result.getOrNull())
+            assertEquals(expectedResult, result.getOrNull())
             coVerify { mockRepository.getPrices(any()) }
         }
 
@@ -69,15 +72,16 @@ class GetPricesTest {
                 listOf(
                     PVPCModel("2023-10-15", 0, 1, 0.15, 0.18),
                 )
+            val expectedResult = PriceFetchResult(expectedPrices, isFromCache = false)
             // The use case will generate today's date when no parameter is passed
-            coEvery { mockRepository.getPrices(any()) } returns Result.success(expectedPrices)
+            coEvery { mockRepository.getPrices(any()) } returns Result.success(expectedResult)
 
             // Act
             val result = useCase()
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(expectedPrices, result.getOrNull())
+            assertEquals(expectedResult, result.getOrNull())
             coVerify { mockRepository.getPrices(any()) }
         }
 

--- a/app/src/test/java/com/codingpit/pvpcplanner/fixtures/FixtureUsageExampleTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/fixtures/FixtureUsageExampleTest.kt
@@ -53,7 +53,7 @@ class FixtureUsageExampleTest {
 
             // Assert - Verify realistic price structure
             assertTrue(priceResult.isSuccess)
-            val prices = priceResult.getOrNull()!!.prices
+            val prices = priceResult.getOrThrow().prices
 
             assertEquals(24, prices.size) // Full day coverage
             assertTrue(
@@ -83,7 +83,8 @@ class FixtureUsageExampleTest {
 
             // Act - Calculate optimal time slots
             val priceResult = getPricesUseCase(TestDates.TYPICAL_DATE)
-            val prices = priceResult.getOrNull()!!.prices
+            assertTrue(priceResult.isSuccess)
+            val prices = priceResult.getOrThrow().prices
 
             val washingSlot = calculateBestTimeSlotUseCase(washingMachine, prices)
             val carChargingSlot = calculateBestTimeSlotUseCase(electricCar, prices)
@@ -171,7 +172,8 @@ class FixtureUsageExampleTest {
 
             // Act
             val priceResult = getPricesUseCase(TestDates.TYPICAL_DATE)
-            val prices = priceResult.getOrNull()!!.prices
+            assertTrue(priceResult.isSuccess)
+            val prices = priceResult.getOrThrow().prices
             val timeSlot = calculateBestTimeSlotUseCase(longDevice, prices)
 
             // Assert - Verify graceful handling of edge case

--- a/app/src/test/java/com/codingpit/pvpcplanner/fixtures/FixtureUsageExampleTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/fixtures/FixtureUsageExampleTest.kt
@@ -3,6 +3,7 @@ package com.codingpit.pvpcplanner.fixtures
 import com.codingpit.pvpcplanner.data.PriceRepositoryImpl
 import com.codingpit.pvpcplanner.data.local.sources.PriceLocalDataSource
 import com.codingpit.pvpcplanner.data.remote.RemoteDataSource
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.strategy.BestTimeSlotCalculationStrategy
 import com.codingpit.pvpcplanner.domain.usecase.CalculateBestTimeSlot
 import com.codingpit.pvpcplanner.domain.usecase.GetPrices
@@ -52,7 +53,7 @@ class FixtureUsageExampleTest {
 
             // Assert - Verify realistic price structure
             assertTrue(priceResult.isSuccess)
-            val prices = priceResult.getOrNull()!!
+            val prices = priceResult.getOrNull()!!.prices
 
             assertEquals(24, prices.size) // Full day coverage
             assertTrue(
@@ -82,7 +83,7 @@ class FixtureUsageExampleTest {
 
             // Act - Calculate optimal time slots
             val priceResult = getPricesUseCase(TestDates.TYPICAL_DATE)
-            val prices = priceResult.getOrNull()!!
+            val prices = priceResult.getOrNull()!!.prices
 
             val washingSlot = calculateBestTimeSlotUseCase(washingMachine, prices)
             val carChargingSlot = calculateBestTimeSlotUseCase(electricCar, prices)
@@ -170,7 +171,7 @@ class FixtureUsageExampleTest {
 
             // Act
             val priceResult = getPricesUseCase(TestDates.TYPICAL_DATE)
-            val prices = priceResult.getOrNull()!!
+            val prices = priceResult.getOrNull()!!.prices
             val timeSlot = calculateBestTimeSlotUseCase(longDevice, prices)
 
             // Assert - Verify graceful handling of edge case

--- a/app/src/test/java/com/codingpit/pvpcplanner/integration/PriceCalculationIntegrationTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/integration/PriceCalculationIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.codingpit.pvpcplanner.data.PriceRepositoryImpl
 import com.codingpit.pvpcplanner.data.local.sources.PriceLocalDataSource
 import com.codingpit.pvpcplanner.data.remote.RemoteDataSource
 import com.codingpit.pvpcplanner.domain.models.Device
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.models.TimeSlot
 import com.codingpit.pvpcplanner.domain.strategy.BestTimeSlotCalculationStrategy
@@ -61,11 +62,11 @@ class PriceCalculationIntegrationTest {
 
             // Act
             val priceResult = getPricesUseCase(date)
-            val bestTimeSlot = calculateBestTimeSlotUseCase(washingMachine, priceResult.getOrThrow())
+            val bestTimeSlot = calculateBestTimeSlotUseCase(washingMachine, priceResult.getOrThrow().prices)
 
             // Assert
             assertTrue(priceResult.isSuccess)
-            assertEquals(5, priceResult.getOrNull()?.size)
+            assertEquals(5, priceResult.getOrNull()?.prices?.size)
 
             // Best slot for 2-hour device should be hours 1-3 (0.10 + 0.08 = 0.18 total)
             assertEquals(TimeSlot(1, 3), bestTimeSlot)
@@ -89,7 +90,7 @@ class PriceCalculationIntegrationTest {
             getPricesFlowUseCase().test {
                 val item = awaitItem()
                 assertTrue(item.isSuccess)
-                assertEquals(2, item.getOrNull()?.size)
+                assertEquals(2, item.getOrNull()?.prices?.size)
                 awaitComplete()
             }
         }
@@ -128,7 +129,7 @@ class PriceCalculationIntegrationTest {
             val priceResult = getPricesUseCase(date)
             assertTrue(priceResult.isSuccess)
 
-            val quickWashSlot = calculateBestTimeSlotUseCase(devices[0], prices)
+            val quickWashSlot = calculateBestTimeSlotUseCase(devices[0], priceResult.getOrThrow().prices)
             val dishwasherSlot = calculateBestTimeSlotUseCase(devices[1], prices)
             val dryerSlot = calculateBestTimeSlotUseCase(devices[2], prices)
 
@@ -186,11 +187,11 @@ class PriceCalculationIntegrationTest {
 
             // Act
             val priceResult = getPricesUseCase(date)
-            val bestSlot = calculateBestTimeSlotUseCase(device, priceResult.getOrThrow())
+            val bestSlot = calculateBestTimeSlotUseCase(device, priceResult.getOrThrow().prices)
 
             // Assert
             assertTrue(priceResult.isSuccess)
-            assertEquals(remotePrices, priceResult.getOrNull())
+            assertEquals(remotePrices, priceResult.getOrNull()?.prices)
             assertEquals(TimeSlot(1, 3), bestSlot) // Hours 1-2 are cheapest (0.12 + 0.10 = 0.22)
         }
 

--- a/app/src/test/java/com/codingpit/pvpcplanner/integration/PriceIntegrationTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/integration/PriceIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.codingpit.pvpcplanner.integration
 import com.codingpit.pvpcplanner.data.PriceRepositoryImpl
 import com.codingpit.pvpcplanner.data.local.sources.PriceLocalDataSource
 import com.codingpit.pvpcplanner.data.remote.RemoteDataSource
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.usecase.GetPrices
 import io.mockk.coEvery
@@ -44,7 +45,8 @@ class PriceIntegrationTest {
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(cachedPrices, result.getOrNull())
+            assertEquals(cachedPrices, result.getOrNull()?.prices)
+            assertEquals(true, result.getOrNull()?.isFromCache)
             coVerify { mockLocalDataSource.getPrices(date) }
             coVerify(exactly = 0) { mockRemoteDataSource.getPrices(any()) }
         }
@@ -68,7 +70,8 @@ class PriceIntegrationTest {
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(remotePrices, result.getOrNull())
+            assertEquals(remotePrices, result.getOrNull()?.prices)
+            assertEquals(false, result.getOrNull()?.isFromCache)
             coVerify { mockLocalDataSource.getPrices(date) }
             coVerify { mockRemoteDataSource.getPrices(date) }
             coVerify { mockLocalDataSource.savePrices(remotePrices) }
@@ -127,7 +130,7 @@ class PriceIntegrationTest {
 
             // Assert
             assertTrue(result.isSuccess)
-            assertEquals(expectedPrices, result.getOrNull())
+            assertEquals(expectedPrices, result.getOrNull()?.prices)
             coVerify { mockLocalDataSource.getPrices(any()) }
         }
 
@@ -149,8 +152,8 @@ class PriceIntegrationTest {
             // Assert
             assertTrue(result1.isSuccess)
             assertTrue(result2.isSuccess)
-            assertEquals(cachedPrices, result1.getOrNull())
-            assertEquals(cachedPrices, result2.getOrNull())
+            assertEquals(cachedPrices, result1.getOrNull()?.prices)
+            assertEquals(cachedPrices, result2.getOrNull()?.prices)
             coVerify(exactly = 2) { mockLocalDataSource.getPrices(date) }
             coVerify(exactly = 0) { mockRemoteDataSource.getPrices(any()) }
         }

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelFunctionTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelFunctionTest.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.ui.devices
 
 import com.codingpit.pvpcplanner.domain.error.ErrorHandler
 import com.codingpit.pvpcplanner.domain.models.Device
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.TimeSlot
 import com.codingpit.pvpcplanner.domain.usecase.AddDevice
 import com.codingpit.pvpcplanner.domain.usecase.CalculateBestTimeSlot
@@ -49,7 +50,7 @@ class DevicesViewModelFunctionTest {
 
         // Set up basic mocks to prevent flow exceptions
         every { mockGetDevices() } returns flowOf(emptyList())
-        every { mockGetPricesFlow() } returns flowOf(Result.success(emptyList()))
+        every { mockGetPricesFlow() } returns flowOf(Result.success(PriceFetchResult(emptyList(), isFromCache = false)))
         every { mockCalculateBestTimeSlot(any(), any()) } returns TimeSlot(0, 1)
         every { mockCalculateDeviceCost(any(), any(), any()) } returns 0.15
     }

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelSimpleTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelSimpleTest.kt
@@ -1,6 +1,7 @@
 package com.codingpit.pvpcplanner.ui.devices
 
 import com.codingpit.pvpcplanner.domain.error.ErrorHandler
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.TimeSlot
 import com.codingpit.pvpcplanner.domain.usecase.AddDevice
 import com.codingpit.pvpcplanner.domain.usecase.CalculateBestTimeSlot
@@ -49,7 +50,7 @@ class DevicesViewModelSimpleTest {
     fun `viewModel can be created`() =
         runTest {
             every { mockGetDevices() } returns flowOf(emptyList())
-            every { mockGetPricesFlow() } returns flowOf(Result.success(emptyList()))
+            every { mockGetPricesFlow() } returns flowOf(Result.success(PriceFetchResult(emptyList(), isFromCache = false)))
             every { mockCalculateBestTimeSlot(any(), any()) } returns TimeSlot(0, 1)
             every { mockCalculateDeviceCost(any(), any(), any()) } returns 0.15
 

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModelTest.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.ui.devices
 
 import com.codingpit.pvpcplanner.domain.error.ErrorHandler
 import com.codingpit.pvpcplanner.domain.models.Device
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.models.TimeSlot
 import com.codingpit.pvpcplanner.domain.strategy.BestTimeSlotCalculationStrategy
@@ -47,7 +48,7 @@ class DevicesViewModelTest {
         Dispatchers.setMain(testDispatcher)
 
         every { mockGetDevices() } returns flowOf(emptyList())
-        every { mockGetPricesFlow() } returns flowOf(Result.success(emptyList()))
+        every { mockGetPricesFlow() } returns flowOf(Result.success(PriceFetchResult(emptyList(), isFromCache = false)))
 
         // Mock the use case to call the real strategy for testing
         every { mockCalculateBestTimeSlot(any(), any()) } answers {

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/home/HomeViewModelTest.kt
@@ -126,6 +126,26 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `state emits Success with isFromCache true when data is from cache`() =
+        runTest {
+            // Arrange
+            val prices =
+                listOf(
+                    PVPCModel("2023-10-15", 10, 11, 0.15, 0.18),
+                )
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = true)), 10)
+
+            // Act & Assert
+            viewModel.state.test {
+                val state = awaitItem()
+                val successState = if (state is HomeState.Loading) awaitItem() else state
+
+                assertTrue(successState is HomeState.Success)
+                assertTrue((successState as HomeState.Success).isFromCache)
+            }
+        }
+
+    @Test
     fun `state emits Error when prices retrieval fails`() =
         runTest {
             // Arrange
@@ -147,8 +167,7 @@ class HomeViewModelTest {
     fun `state emits Error when getOrThrow fails due to missing data`() =
         runTest {
             // Arrange
-            val prices = emptyList<PVPCModel>()
-            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)))
+            val viewModel = createViewModel(Result.success(PriceFetchResult(emptyList(), isFromCache = false)))
 
             // Act & Assert
             viewModel.state.test {
@@ -169,7 +188,7 @@ class HomeViewModelTest {
                     PVPCModel("2023-10-15", 8, 9, 0.15, 0.18),
                     PVPCModel("2023-10-15", 9, 10, 0.12, 0.16),
                 )
-            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)), 11) // Hour not in prices list
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)), 11)
 
             // Act & Assert
             viewModel.state.test {
@@ -197,7 +216,7 @@ class HomeViewModelTest {
                 if (state is HomeState.Loading) {
                     state = awaitItem()
                 }
-                assertTrue(state is HomeState.Success) // Ensure we started at success
+                assertTrue(state is HomeState.Success)
 
                 // Act
                 viewModel.onPreviousClicked()

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/home/HomeViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.codingpit.pvpcplanner.domain.error.ErrorHandler
 import com.codingpit.pvpcplanner.domain.models.DarkMode
+import com.codingpit.pvpcplanner.domain.models.PriceFetchResult
 import com.codingpit.pvpcplanner.domain.models.PVPCModel
 import com.codingpit.pvpcplanner.domain.models.Settings
 import com.codingpit.pvpcplanner.domain.models.TimeFormat
@@ -58,7 +59,7 @@ class HomeViewModelTest {
     private val mockErrorHandler = mockk<ErrorHandler>()
 
     private fun createViewModel(
-        prices: Result<List<PVPCModel>> = Result.success(emptyList()),
+        prices: Result<PriceFetchResult> = Result.success(PriceFetchResult(emptyList(), isFromCache = false)),
         currentHour: Int = 10,
     ): HomeViewModel {
         val testDate = LocalDate.of(2023, 10, 15)
@@ -107,7 +108,7 @@ class HomeViewModelTest {
                     PVPCModel("2023-10-15", 10, 11, 0.15, 0.18),
                     PVPCModel("2023-10-15", 11, 12, 0.12, 0.16),
                 )
-            val viewModel = createViewModel(Result.success(prices), 10)
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)), 10)
 
             // Act & Assert
             viewModel.state.test {
@@ -147,7 +148,7 @@ class HomeViewModelTest {
         runTest {
             // Arrange
             val prices = emptyList<PVPCModel>()
-            val viewModel = createViewModel(Result.success(prices))
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)))
 
             // Act & Assert
             viewModel.state.test {
@@ -168,7 +169,7 @@ class HomeViewModelTest {
                     PVPCModel("2023-10-15", 8, 9, 0.15, 0.18),
                     PVPCModel("2023-10-15", 9, 10, 0.12, 0.16),
                 )
-            val viewModel = createViewModel(Result.success(prices), 11) // Hour not in prices list
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)), 11) // Hour not in prices list
 
             // Act & Assert
             viewModel.state.test {
@@ -184,10 +185,10 @@ class HomeViewModelTest {
         runTest {
             // Arrange
             val prices = listOf(PVPCModel("2023-10-14", 10, 11, 0.15, 0.18))
-            val viewModel = createViewModel(Result.success(prices))
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)))
 
             // Mock the prices for the new date
-            coEvery { mockGetPrices("2023-10-14") } returns Result.success(prices)
+            coEvery { mockGetPrices("2023-10-14") } returns Result.success(PriceFetchResult(prices, isFromCache = false))
 
             // Act & Assert
             viewModel.state.test {
@@ -217,10 +218,10 @@ class HomeViewModelTest {
         runTest {
             // Arrange
             val prices = listOf(PVPCModel("2023-10-16", 10, 11, 0.15, 0.18))
-            val viewModel = createViewModel(Result.success(prices))
+            val viewModel = createViewModel(Result.success(PriceFetchResult(prices, isFromCache = false)))
 
             // Mock the prices for the new date
-            coEvery { mockGetPrices("2023-10-16") } returns Result.success(prices)
+            coEvery { mockGetPrices("2023-10-16") } returns Result.success(PriceFetchResult(prices, isFromCache = false))
 
             // Act & Assert
             viewModel.state.test {


### PR DESCRIPTION
## Summary
- Adds \`PriceFetchResult\` domain model wrapping price data with an \`isFromCache\` flag
- \`PriceRepositoryImpl\` returns \`isFromCache = true\` when serving from Room cache, \`false\` when fetched from network
- \`HomeState.Success\` exposes \`isFromCache\` to the UI layer
- \`HomeScreen\` displays a banner when prices come from cache so users know data may be stale
- All affected tests updated

## Test plan
- [ ] With no network, open app — verify "Showing cached data" banner appears
- [ ] With network, open app on a fresh date — verify no banner shown
- [ ] Run \`./gradlew testDebugUnitTest\` — all tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Indicate when Home screen price data is coming from cache and propagate cache metadata through the pricing domain and repository layer.

New Features:
- Expose a PriceFetchResult domain model that wraps price lists with an isFromCache flag.
- Surface an isFromCache property in HomeState.Success so the UI can react to cached data.
- Show a cached data banner on the Home screen when prices are served from local storage.

Enhancements:
- Update PriceRepository, GetPrices, and GetPricesFlow to return PriceFetchResult instead of raw price lists, and adapt DevicesViewModel and other consumers to use the wrapped data.

Tests:
- Adjust unit and integration tests across pricing, repository, devices, and home view model layers to work with PriceFetchResult and to verify cache vs network behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cache indicator banner that displays when the app shows previously stored price data, helping users understand data freshness and when to reconnect for the latest market prices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->