### PR TITLE
build: add Jacoco code coverage configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,8 +72,9 @@ android {
             )
         }
         debug {
-            enableAndroidTestCoverage = true
-            enableUnitTestCoverage = true
+            val coverageEnabled = project.hasProperty("coverage")
+            enableAndroidTestCoverage = coverageEnabled
+            enableUnitTestCoverage = coverageEnabled
         }
     }
     compileOptions {
@@ -108,11 +109,11 @@ android {
 }
 
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = libs.versions.jacoco.get()
     reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
 }
 
-tasks.withType(Test::class) {
+tasks.withType<Test>().configureEach {
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true
         excludes = listOf("jdk.internal.*")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,11 +106,9 @@ android {
         reportsDestination = layout.buildDirectory.dir("compose_reports")
         metricsDestination = layout.buildDirectory.dir("compose_metrics")
     }
-}
-
-jacoco {
-    toolVersion = libs.versions.jacoco.get()
-    reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
+    jacoco {
+        version = libs.versions.jacoco.get()
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.dagger.hilt.android.plugin)
     alias(libs.plugins.protobuf)
     alias(libs.plugins.roborazzi)
+    jacoco
 }
 
 android {
@@ -70,6 +71,10 @@ android {
                 "proguard-rules.pro",
             )
         }
+        debug {
+            enableAndroidTestCoverage = true
+            enableUnitTestCoverage = true
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -99,6 +104,18 @@ android {
     composeCompiler {
         reportsDestination = layout.buildDirectory.dir("compose_reports")
         metricsDestination = layout.buildDirectory.dir("compose_metrics")
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+    reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
+}
+
+tasks.withType(Test::class) {
+    configure<JacocoTaskExtension> {
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 activityCompose = "1.13.0"
+jacoco = "0.8.12"
 agp = "9.2.0"
 composeBom = "2026.04.01"
 coreKtx = "1.18.0"


### PR DESCRIPTION
## Summary
- Port Jacoco setup originally authored by @marta-maquedano (Dec 2024) from `feature/code-coverage-prs`
- Adds `jacoco` plugin to `app/build.gradle.kts`
- Enables `enableAndroidTestCoverage` and `enableUnitTestCoverage` in debug build type
- Configures Jacoco tool version `0.8.12` with custom reports directory
- Configures `JacocoTaskExtension` on all Test tasks to include no-location classes

## Test plan
- [ ] `./gradlew testDebugUnitTest` runs without build errors
- [ ] Jacoco coverage report generated in `build/customJacocoReportDir`
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Jacoco-based code coverage support to the Android app module.

Enhancements:
- Enable unit and instrumentation test coverage for the debug build type and configure test tasks to include no-location classes while excluding internal JDK classes.

Build:
- Apply the Jacoco Gradle plugin and configure tool version and custom reports directory in the app module build script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled code coverage collection for debug builds, supporting both unit and instrumentation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->