### PR TITLE
chore: wire the-archive skills and MCP into project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,22 +375,22 @@ Do **not** log: trivial typos, missing imports that the IDE auto-fixes, or failu
 
 ### How to log a failure
 
-After resolving a failure, check if `.claude/archive-pending.json` exists — the hook writes failure details there automatically. Use it as context.
+After resolving a failure, check if `.claude/archive-pending.json` exists — the hook writes failure details there automatically. Read it and use its `error` and `context` fields as input to the steps below.
 
 #### 1. Check if already documented
 
-Use the `the-archive` MCP before creating a new entry:
+Use the `the-archive` MCP before creating a new entry. Pass the error message text directly as a string argument:
 
 ```
-find_similar(error_text="<paste the error message>")
-search_errors(query="<keywords>", technology="android")
+find_similar(error_text="<paste the exact error message from archive-pending.json>")
+search_errors(query="<keywords from the error>", technology="android")
 ```
 
 If a matching entry exists, use the **`archive-append-attempt`** skill to record your attempt instead.
 
 #### 2. Create a new entry
 
-If not documented, use the **`archive-create-error`** skill. It scaffolds the directory, runs all validators, and opens the PR automatically.
+If not documented, use the **`archive-create-error`** skill. Pass the contents of `.claude/archive-pending.json` as context — the skill reads the `error`, `context`, and `solution` fields from it. It scaffolds the directory, runs all validators, and opens the PR automatically.
 
 #### 3. Clean up
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,84 +375,25 @@ Do **not** log: trivial typos, missing imports that the IDE auto-fixes, or failu
 
 ### How to log a failure
 
-After resolving a failure, check if `.claude/archive-pending.json` exists — the hook writes failure details there automatically. Use it as a starting point.
+After resolving a failure, check if `.claude/archive-pending.json` exists — the hook writes failure details there automatically. Use it as context.
 
-Then follow these steps:
+#### 1. Check if already documented
 
-#### 1. Determine the ID
+Use the `the-archive` MCP before creating a new entry:
 
-Check `INDEX.md` in the-archive repo to find the next available number:
-```bash
-gh api repos/Coding-Pit-Dev/the-archive/contents/INDEX.md --jq '.content' | base64 -d
+```
+find_similar(error_text="<paste the error message>")
+search_errors(query="<keywords>", technology="android")
 ```
 
-Use prefix `AND-` for Android/Kotlin/Compose issues, `AGP-` for Gradle/build issues.
+If a matching entry exists, use the **`archive-append-attempt`** skill to record your attempt instead.
 
-#### 2. Clone the-archive and create a branch
+#### 2. Create a new entry
 
-```bash
-gh repo clone Coding-Pit-Dev/the-archive /tmp/the-archive 2>/dev/null || git -C /tmp/the-archive pull
-cd /tmp/the-archive && git checkout -b errors/AND-NNN-short-description
-mkdir -p errors/android/<subcategory>/AND-NNN-short-description
-```
+If not documented, use the **`archive-create-error`** skill. It scaffolds the directory, runs all validators, and opens the PR automatically.
 
-#### 3. Write the error document
-
-Create `errors/android/<subcategory>/AND-NNN-short-description/README.md` with this exact frontmatter:
-
-```yaml
----
-id: "AND-NNN"
-title: "Short descriptive title"
-technology: ["android", "kotlin"]
-severity: "blocker"                   # blocker | high | medium | low
-status: "solved"                      # solved | partial | unsolved
-tags: ["compose", "tag2"]             # lowercase, max 8
-created: "YYYY-MM-DD"
-last_updated: "YYYY-MM-DD"
-success_count: 0
-contributors:
-  - agent: "claude-sonnet-4-6"
-    pr: ""                            # fill after PR is created
-    date: "YYYY-MM-DD"
----
-```
-
-Required body sections: `## Error description`, `## When it appears`, `## Root cause`, `## Solution`, `## Verification`, `## Environment`, `## References`.
-
-#### 4. Submit the PR
-
-```bash
-cd /tmp/the-archive
-git add .
-git commit -m "errors: add AND-NNN short description"
-git push origin errors/AND-NNN-short-description
-gh pr create --repo Coding-Pit-Dev/the-archive \
-  --title "errors: AND-NNN short description" \
-  --body "$(cat <<'EOF'
-## Summary
-- New error entry AND-NNN
-- Technology: android/kotlin
-- Status: solved
-
-## PR checklist
-- [ ] Frontmatter is valid and complete
-- [ ] ID is unique (verified against INDEX.md)
-- [ ] No executable code outside scripts/
-- [ ] last_updated is today's date
-EOF
-)"
-```
-
-#### 5. Clean up
+#### 3. Clean up
 
 ```bash
 rm -f .claude/archive-pending.json
 ```
-
-### ID reference (as of 2026-04-07)
-
-| Next ID | Technology |
-|---------|-----------|
-| AND-003 | Android general / Kotlin / Compose |
-| AGP-002 | Android Gradle Plugin / build |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 PVPC-Android is an electricity price management application for Android that helps users optimize their appliance usage based on PVPC (Voluntary Price for Small Consumers) electricity rates in Spain. The app calculates the best time slots to run appliances based on real-time pricing data.
 
+## Working on Tasks — Worktree Requirement
+
+**Every non-trivial code task must be done in a git worktree.** This keeps the main working tree clean and makes it safe to parallelize or abandon work.
+
+### Workflow
+
+```bash
+# 1. Create worktree from develop
+git worktree add .claude/worktrees/<short-name> -b <branch-name> develop
+
+# 2. Do all work inside that directory
+cd .claude/worktrees/<short-name>
+
+# 3. Commit, push, open PR
+git push -u origin <branch-name>
+gh pr create --base develop ...
+
+# 4. Remove worktree when PR is open (or abandoned)
+cd /path/to/main/repo
+git worktree remove .claude/worktrees/<short-name>
+```
+
+Exceptions — work directly in the main tree only when:
+- Fixing a hook or settings file that affects the worktree itself
+- Responding to an existing PR's review comments on the same branch
+
 ## Build & Test Commands
 
 ### Building


### PR DESCRIPTION
## Summary
- Replaces verbose manual archive logging steps in `CLAUDE.md` with skill references (`archive-create-error`, `archive-append-attempt`)
- Adds `the-archive` MCP query step before creating a new entry (dedup via `find_similar` / `search_errors`)
- Skills and MCP were missing; installed globally this session:
  - Skills copied to `~/.claude/skills/`
  - `the-archive-mcp` installed via `uv tool install` and registered with `claude mcp add --scope user`

## What changed
- `CLAUDE.md` §"How to log a failure": 68 lines → 9 lines; manual clone/scaffold/validate steps replaced by skill invocations

## Test plan
- [ ] Open a session in this repo and confirm `archive-create-error` and `archive-append-attempt` appear in available skills
- [ ] Confirm `the-archive` MCP tools (`find_similar`, `search_errors`) are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the failure logging workflow by delegating archive management to preconfigured skills and MCP tools instead of manual git and PR steps.

Enhancements:
- Replace detailed manual instructions for creating and updating error entries in the-archive with high-level guidance that uses `archive-create-error` and `archive-append-attempt` skills.
- Introduce use of the `the-archive` MCP tools (`find_similar`, `search_errors`) to check for existing documentation before creating new entries.
- Streamline cleanup instructions after logging a failure while removing obsolete ID reference and repository management details from the guide.