### PR TITLE
chore: fix detekt version, enable UnusedImports, improve error handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,7 +140,7 @@ ktlint {
 }
 
 detekt {
-    toolVersion = "1.23.7"
+    toolVersion = libs.versions.detekt.get()
     parallel = true
     config.setFrom("config/detekt/config.yml")
     buildUponDefaultConfig = true

--- a/app/config/detekt/config.yml
+++ b/app/config/detekt/config.yml
@@ -731,7 +731,7 @@ style:
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
-    active: false
+    active: true
   UnusedParameter:
     active: true
     allowedNames: 'ignored|expected'

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModel.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.ui.devices
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.codingpit.pvpcplanner.domain.error.ErrorHandler
 import com.codingpit.pvpcplanner.domain.models.Device
 import com.codingpit.pvpcplanner.domain.models.DeviceCategory
 import com.codingpit.pvpcplanner.domain.usecase.AddDevice
@@ -25,6 +26,7 @@ class DeviceAddViewModel
         private val addDevice: AddDevice,
         private val updateDevice: UpdateDevice,
         private val dispatcher: CoroutineDispatcher,
+        private val errorHandler: ErrorHandler,
     ) : ViewModel() {
         private val _state = MutableStateFlow<DeviceAddState>(DeviceAddState.Loading)
         val state: StateFlow<DeviceAddState> = _state.asStateFlow()
@@ -169,11 +171,8 @@ class DeviceAddViewModel
 
                     onSuccess()
                 } catch (e: Exception) {
-                    _state.value =
-                        DeviceAddState.Error(
-                            error = e.message ?: "Error saving device",
-                            isSaving = false,
-                        )
+                    val errorResult = errorHandler.handleError(e, "device_save")
+                    _state.value = DeviceAddState.Factory.createErrorState(errorResult)
                 }
             }
         }

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModel.kt
@@ -171,7 +171,7 @@ class DeviceAddViewModel
 
                     onSuccess()
                 } catch (e: Exception) {
-                    val errorResult = errorHandler.handleError(e, "device_save")
+                    val errorResult = errorHandler.handleError(e, ERROR_CONTEXT_SAVE)
                     _state.value = DeviceAddState.Factory.createErrorState(errorResult)
                 }
             }
@@ -216,5 +216,9 @@ class DeviceAddViewModel
                     state
                 }
             }
+        }
+
+        companion object {
+            private const val ERROR_CONTEXT_SAVE = "device_save"
         }
     }

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModelTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModelTest.kt
@@ -3,12 +3,16 @@ package com.codingpit.pvpcplanner.ui.devices
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import com.codingpit.pvpcplanner.domain.error.ErrorHandler
+import com.codingpit.pvpcplanner.domain.error.ErrorResult
 import com.codingpit.pvpcplanner.domain.usecase.AddDevice
 import com.codingpit.pvpcplanner.domain.usecase.UpdateDevice
 import com.codingpit.pvpcplanner.utils.CategoryUiModel
 import com.codingpit.pvpcplanner.utils.DeviceIcon
+import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -84,6 +88,27 @@ class DeviceAddViewModelTest {
                     },
                 )
             }
+        }
+
+    @Test
+    fun `saveDevice transitions to Error state when addDevice throws`() =
+        runTest {
+            val icons = listOf(DeviceIcon("icon1", Icons.Default.Add, 0))
+            val categories = listOf(CategoryUiModel("cat1", 0))
+            viewModel.initialize(icons, categories)
+
+            coEvery { mockAddDevice(any()) } throws RuntimeException("test error")
+            every { mockErrorHandler.handleError(any(), any()) } returns ErrorResult.UnknownError("test error")
+
+            viewModel.onDeviceNameChanged("Test Device")
+            viewModel.onWattsChanged("100")
+            viewModel.onHoursChanged("2")
+
+            viewModel.saveDevice {}
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify { mockErrorHandler.handleError(any(), any()) }
+            assert(viewModel.state.value is DeviceAddState.Error)
         }
 
     @Test

--- a/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModelTest.kt
+++ b/app/src/test/java/com/codingpit/pvpcplanner/ui/devices/DeviceAddViewModelTest.kt
@@ -2,6 +2,7 @@ package com.codingpit.pvpcplanner.ui.devices
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import com.codingpit.pvpcplanner.domain.error.ErrorHandler
 import com.codingpit.pvpcplanner.domain.usecase.AddDevice
 import com.codingpit.pvpcplanner.domain.usecase.UpdateDevice
 import com.codingpit.pvpcplanner.utils.CategoryUiModel
@@ -23,13 +24,14 @@ import org.junit.Test
 class DeviceAddViewModelTest {
     private val mockAddDevice = mockk<AddDevice>(relaxed = true)
     private val mockUpdateDevice = mockk<UpdateDevice>(relaxed = true)
+    private val mockErrorHandler = mockk<ErrorHandler>(relaxed = true)
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var viewModel: DeviceAddViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = DeviceAddViewModel(mockAddDevice, mockUpdateDevice, testDispatcher)
+        viewModel = DeviceAddViewModel(mockAddDevice, mockUpdateDevice, testDispatcher, mockErrorHandler)
     }
 
     @After


### PR DESCRIPTION
## Summary
- Align `detekt.toolVersion` to reference `libs.versions.detekt.get()` instead of hardcoded `1.23.7` (was out-of-sync with `libs.versions.toml` which had `1.23.8`)
- Enable `UnusedImports` rule in detekt config
- Inject `ErrorHandler` into `DeviceAddViewModel` and replace generic `catch(Exception)` + hardcoded `"Error saving device"` string with proper `errorHandler.handleError()` delegation

## Test plan
- [ ] `./gradlew ktlintCheck detekt` passes
- [ ] `./gradlew compileDebugKotlin` builds cleanly
- [ ] DeviceAddViewModel test verifies error state uses ErrorHandler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align static analysis configuration and improve error handling in device creation flow.

Enhancements:
- Inject a shared ErrorHandler into DeviceAddViewModel and delegate device save failures to centralized error handling.
- Update detekt configuration to enable the UnusedImports rule and use the version from the shared versions catalog instead of a hardcoded value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Use centralized version management for tooling and enable stricter unused-import checks.

* **Improvements**
  * Enhanced error handling for device save operations to provide clearer, consistent feedback to users.

* **Tests**
  * Updated unit test wiring to reflect the new error-handling integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->