### PR TITLE
perf: decouple device cost calculation from search/filter, fix SimpleDateFormat alloc

### DIFF
--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/components/PricesComponent.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/components/PricesComponent.kt
@@ -140,9 +140,10 @@ private fun formatHour(
     currentHour: Int,
     timeFormat: TimeFormat,
 ): String {
+    val locale = LocalConfiguration.current.locales[0]
+    val sdf = remember(locale) { SimpleDateFormat("h a", locale) }
     val formattedHour =
         if (timeFormat == TimeFormat.TWELVE_HOURS) {
-            val sdf = SimpleDateFormat("h a", LocalConfiguration.current.locales[0])
             sdf.format(
                 Calendar
                     .getInstance()

--- a/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
+++ b/app/src/main/java/com/codingpit/pvpcplanner/ui/devices/DevicesViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -39,20 +40,24 @@ class DevicesViewModel
         private val searchQuery = MutableStateFlow("")
         private val selectedCategory = MutableStateFlow<DeviceCategoryFilter?>(null)
 
+        private val deviceRenders =
+            combine(getDevices(), getPricesFlow()) { devices, prices ->
+                prices.map { fetchResult ->
+                    devices.map { device ->
+                        val bestSlot = calculateBestTimeSlot(device, fetchResult.prices)
+                        val cost = calculateDeviceCost(device, bestSlot, fetchResult.prices)
+                        DeviceRender(device, bestSlot, cost)
+                    }
+                }
+            }.distinctUntilChanged()
+
         val state =
             combine(
-                getDevices(),
-                getPricesFlow(),
+                deviceRenders,
                 searchQuery,
                 selectedCategory,
-            ) { devices, prices, query, category ->
-                prices.map { fetchResult ->
-                    val devicesSlot =
-                        devices.map { device ->
-                            val bestSlot = calculateBestTimeSlot(device, fetchResult.prices)
-                            val cost = calculateDeviceCost(device, bestSlot, fetchResult.prices)
-                            DeviceRender(device, bestSlot, cost)
-                        }
+            ) { renders, query, category ->
+                renders.map { devicesSlot ->
                     DevicesState.Success(devicesSlot = devicesSlot, searchQuery = query, selectedCategory = category)
                 }
             }.map { it.getOrThrow() }


### PR DESCRIPTION
## Summary
- **DevicesViewModel**: split 4-way `combine` into two stages — device slot/cost calculation (expensive O(n×devices)) now only runs when `devices` or `prices` change, not on every search query keystroke. Outer combine handles query/category filtering.
- **PricesComponent**: wrap `SimpleDateFormat("h a")` in `remember(locale)` — was creating a new object on every recomposition of `formatHour` in the price list.

## Before / After
| File | Before | After |
|------|--------|-------|
| DevicesViewModel | 4-way combine recalculates all costs on query change | Inner flow recalculates only on data change; outer combines query/filter |
| PricesComponent | `SimpleDateFormat` allocated per render | `remember(locale)` — single allocation, reused across recompositions |

## Test plan
- [ ] `./gradlew :app:compileDebugKotlin` — builds cleanly
- [ ] `./gradlew ktlintCheck detekt` — no violations
- [ ] `./gradlew testDebugUnitTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize device rendering and price display performance by decoupling device cost computation from search/filter state and avoiding repeated date formatter allocations.

Enhancements:
- Precompute device render models from devices and prices in a dedicated flow so cost and slot calculations only recompute when underlying data changes, not on search or category updates.
- Reuse a remembered SimpleDateFormat instance keyed by locale in the prices component to prevent unnecessary allocations on recomposition.